### PR TITLE
ML: Adding dco as per contributing standards

### DIFF
--- a/dco/michael_j_lee.dco
+++ b/dco/michael_j_lee.dco
@@ -1,0 +1,9 @@
+1) I, Michael J Lee, certify that all work committed with the commit message
+"covered by: michael_j_lee.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2020-06-19 to 9999-01-01.


### PR DESCRIPTION
I tried updating the Notice.txt as per https://github.com/goldmansachs/obevo/blob/master/CONTRIBUTING.md but it blew up the CI so I'm not touching it this time around.  